### PR TITLE
Count newlines separately even if they are side by side

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function (str) {
 		throw new TypeError('Expected a string');
 	}
 
-	var newlines = (str.match(/(?:\r?\n)+/g) || []);
+	var newlines = (str.match(/(?:\r?\n)/g) || []);
 	var crlf = newlines.filter(function (el) { return el === '\r\n'; }).length;
 	var lf = newlines.length - crlf;
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var detectNewline = require('./');
 
 it('should return the used newline character', function () {
+	assert.equal(detectNewline('foo\r\nbar\r\nbaz\n\n\n'), '\n');
 	assert.equal(detectNewline('foo\r\nbar\r\nbaz\n'), '\r\n');
 	assert.equal(detectNewline('foo\nbar\nbaz\r\n'), '\n');
 	assert.equal(detectNewline('foo\nbar\r\n'), '\n');


### PR DESCRIPTION
Previously, detect-newline would report `\n` as the dominant newline character in `foo\r\nbar\r\nbaz\n\n\n` even though `\n` occurs more often.
