### PR TITLE
Return null if no newlines were found

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,7 @@ var cli = meow({
 });
 
 function init(data) {
-	process.stdout.write(detectNewline(data));
+	process.stdout.write(detectNewline(data) || '');
 }
 
 if (process.stdin.isTTY) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,12 @@ module.exports = function (str) {
 		throw new TypeError('Expected a string');
 	}
 
-	var newlines = (str.match(/(?:\r?\n)/g) || []);
+	var newlines = str.match(/(?:\r?\n)/g);
+
+	if (!newlines) {
+		return null;
+	}
+
 	var crlf = newlines.filter(function (el) { return el === '\r\n'; }).length;
 	var lf = newlines.length - crlf;
 

--- a/test.js
+++ b/test.js
@@ -7,4 +7,5 @@ it('should return the used newline character', function () {
 	assert.equal(detectNewline('foo\r\nbar\r\nbaz\n'), '\r\n');
 	assert.equal(detectNewline('foo\nbar\nbaz\r\n'), '\n');
 	assert.equal(detectNewline('foo\nbar\r\n'), '\n');
+	assert.equal(detectNewline('foo'), null);
 });


### PR DESCRIPTION
When being used programmatically, it returns null if no newlines were found. On the command line, it simply returns an empty string.

If you would rather have the programmatic interface also return an empty string, I’d be happy to update this PR.
